### PR TITLE
debug can take a callback to receive debugging line

### DIFF
--- a/lib/JSON/RPC2/TwoWay.pm
+++ b/lib/JSON/RPC2/TwoWay.pm
@@ -3,7 +3,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-our $VERSION = '0.06'; # VERSION
+our $VERSION = '0.07'; # VERSION
 
 # standard perl
 use Carp;

--- a/lib/JSON/RPC2/TwoWay/Connection.pm
+++ b/lib/JSON/RPC2/TwoWay/Connection.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-our $VERSION = '0.06'; # VERSION
+our $VERSION = '0.07'; # VERSION
 
 # standard perl
 use Carp;


### PR DESCRIPTION
Allow debug to be a coderef and call that with the debugging line, otherwise if debug is true print to stderr.

This seemed like an economical way of providing more control over output in debug mode. But if you would like it configured in some other way, let me know, and I'm happy to do it that way.
