### PR TITLE
Reduced encodes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,6 +17,7 @@ issues = 1
 [Prereqs]
 perl = 5.010
 JSON::MaybeXS = 0
+Time::HiRes = 0
 
 [PruneFiles]
 match = ~$

--- a/lib/JSON/RPC2/TwoWay.pm
+++ b/lib/JSON/RPC2/TwoWay.pm
@@ -3,7 +3,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-our $VERSION = '0.07'; # VERSION
+our $VERSION = '0.08'; # VERSION
 
 # standard perl
 use Carp;

--- a/lib/JSON/RPC2/TwoWay/Connection.pm
+++ b/lib/JSON/RPC2/TwoWay/Connection.pm
@@ -4,7 +4,7 @@ use 5.10.0;
 use strict;
 use warnings;
 
-our $VERSION = '0.07'; # VERSION
+our $VERSION = '0.08'; # VERSION
 
 # standard perl
 use Carp;

--- a/lib/JSON/RPC2/TwoWay/Connection.pm
+++ b/lib/JSON/RPC2/TwoWay/Connection.pm
@@ -11,6 +11,11 @@ use Carp;
 use Data::Dumper;
 use Digest::MD5 qw(md5_base64);
 use Scalar::Util qw(refaddr weaken);
+use Time::HiRes qw();
+
+*mono_time = eval { Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) }
+    ? sub () { Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) }
+    : \&Time::HiRes::time;
 
 # cpan
 use JSON::MaybeXS qw();
@@ -45,7 +50,7 @@ sub call {
 		unless ref $args eq 'ARRAY' or ref $args eq 'HASH';
 	croak 'no callback?' unless $cb;
 	croak 'callback should be a code reference' if ref $cb ne 'CODE';
-	my $id = md5_base64($self->{next_id}++ . $name . $self->{json}->encode($args) . refaddr($cb));
+	my $id = md5_base64(mono_time() . rand . refaddr($args));
 	croak 'duplicate call id' if $self->{calls}->{$id};
 	my $request = $self->{json}->encode({
 		jsonrpc => '2.0',
@@ -65,7 +70,7 @@ sub callraw {
 	croak 'request should be a array or hash reference'
 		unless ref $request eq 'HASH';
 	croak 'callback should be a code reference' if ref $cb ne 'CODE';
-	my $id = md5_base64($self->{next_id}++ . $self->{json}->encode($request) . refaddr($cb));
+	my $id = md5_base64(mono_time() . rand . refaddr($request));
 	croak 'duplicate call id' if $self->{calls}->{$id};
 	$request->{jsonrpc} = '2.0';
 	$request->{id} = $id;


### PR DESCRIPTION
Most of the payload is getting json encoded twice: once to generate the id and again for the json rpc message.

Here I take a very similar approach to `Mojo::IOLoop` for generating the id. 

I have removed the counter as monotonic time + `rand` should provide enough uniqueness. I am also using the `refaddr` of the argument most likely to change from call to call.

Let me know if you don't think this provides enough randomness.

## Benchmarks

I carried out some benchmarks by calling different versions of the functions with the write disabled to measure throughput:

* in the "best case" scenario the new version performs somewhat worse ~ 0.7x.
* in every other the new version performs between somewhat better ~ 1.4x and much better ~ 3x.

### Table

version | method | scenario | bytes | calls_per_sec | comparison
-- | -- | -- | -- | -- | --
new | callraw | best | 2 | 440528.63 | 70.93%
new | call | best | 2 | 328947.37 | 67.76%
new | callraw | average1 | 1011 | 289017.34 | 144.22%
new | call | average1 | 1011 | 243902.44 | 130.00%
new | callraw | average2 | 2011 | 226244.34 | 180.09%
new | call | average2 | 2011 | 204918.03 | 167.42%
new | callraw | worst | 900011 | 1196.17 | 310.77%
new | call | worst | 900011 | 1133.79 | 300.91%
old | callraw | best | 2 | 621118.01 | 140.99%
old | call | best | 2 | 485436.89 | 147.57%
old | callraw | average1 | 1011 | 200400.8 | 69.34%
old | call | average1 | 1011 | 187617.26 | 76.92%
old | callraw | average2 | 2011 | 125628.14 | 55.53%
old | call | average2 | 2011 | 122399.02 | 59.73%
old | callraw | worst | 900011 | 384.91 | 32.18%
old | call | worst | 900011 | 376.79 | 33.23%



